### PR TITLE
Fix bike shop condition

### DIFF
--- a/ansible/roles/tilemaker/templates/bicycle/process-openmaptiles.lua
+++ b/ansible/roles/tilemaker/templates/bicycle/process-openmaptiles.lua
@@ -633,6 +633,17 @@ function WritePOI(obj,class,subclass,rank)
 		obj:Attribute("pump", obj:Find("service:bicycle:pump"))
 		obj:Attribute("tools", obj:Find("service:bicycle:tools"))
 	end
+
+	if subclass=="sports" then
+		local isBike = "no"
+		local repair = obj:Find("service:bicycle:repair") == "yes"
+		local retail = obj:Find("service:bicycle:retail") == "yes"
+		local second_hand = obj:Find("service:bicycle:second_hand") == "yes"
+		if repair or retail or second_hand then
+			isBike = "yes"
+		end
+		obj:Attribute("bike", isBike)
+	end
 end
 
 -- Set name attributes on any object

--- a/ansible/roles/tilemaker/templates/bicycle/style.json
+++ b/ansible/roles/tilemaker/templates/bicycle/style.json
@@ -2214,7 +2214,8 @@
         "all",
         ["==", "$type", "Point"],
         ["==", "class", "shop"],
-        ["==", "subclass", "bicycle"]
+        ["in", "subclass", "bicycle", "sports"],
+        ["any", ["!has", "bike"], ["==", "bike", "yes"]]
       ],
       "layout": {
         "icon-image": "bicycle_shop_11",


### PR DESCRIPTION
Based on [#17](https://github.com/buskerudbyen/cycling-norway/issues/17#issuecomment-1475870723).

Shops are added to the map (`poi-bicycle-shop` POI) if:
* `shop = bicycle`
* or `shop = sports` and `service:bicycle:repair = yes` or `service:bicycle:retail = yes` or `service:bicycle:second_hand = yes`

I looked through the [service:bicycle:* Wiki](https://wiki.openstreetmap.org/wiki/Key:service:bicycle:*) and it seems these are the possible keys for bike-related shopping. Let me know if I should add any more. (`service:bicycle:cleaning` or `service:bicycle:rental` ?)

Example: [XXL Drammen](https://overpass-turbo.eu/s/1sLz)