### PR TITLE
Add sport facilities to the map

### DIFF
--- a/ansible/roles/tilemaker/templates/bicycle/process-openmaptiles.lua
+++ b/ansible/roles/tilemaker/templates/bicycle/process-openmaptiles.lua
@@ -153,11 +153,11 @@ landcoverKeys   = { wood="wood", forest="wood",
 poiTags         = { aerialway = Set { "station" },
 					amenity = Set { "arts_centre", "bank", "bar", "bbq", "bicycle_parking", "bicycle_rental", "bicycle_repair_station", "biergarten", "bus_station", "cafe", "cinema", "clinic", "college", "community_centre", "compressed_air", "courthouse", "dentist", "doctors", "embassy", "fast_food", "ferry_terminal", "fire_station", "food_court", "fuel", "grave_yard", "hospital", "ice_cream", "kindergarten", "library", "marketplace", "motorcycle_parking", "nightclub", "nursing_home", "parking", "pharmacy", "place_of_worship", "police", "post_box", "post_office", "prison", "pub", "public_building", "recycling", "restaurant", "school", "shelter", "swimming_pool", "taxi", "telephone", "theatre", "toilets", "townhall", "university", "veterinary", "waste_basket" },
 					barrier = Set { "bollard", "border_control", "cycle_barrier", "gate", "lift_gate", "sally_port", "stile", "toll_booth" },
-					building = Set { "dormitory" },
+					building = Set { "dormitory", "sports_centre" },
 					highway = Set { "bus_stop" },
 					historic = Set { "monument", "castle", "ruins" },
 					landuse = Set { "basin", "brownfield", "cemetery", "reservoir", "winter_sports" },
-					leisure = Set { "dog_park", "escape_game", "garden", "golf_course", "ice_rink", "hackerspace", "marina", "miniature_golf", "park", "pitch", "playground", "sports_centre", "stadium", "swimming_area", "swimming_pool", "water_park" },
+					leisure = Set { "dog_park", "escape_game", "garden", "golf_course", "ice_rink", "hackerspace", "marina", "miniature_golf", "park", "pitch", "playground", "sports_centre", "stadium", "swimming_area", "swimming_pool", "track", "water_park" },
 					railway = Set { "halt", "station", "subway_entrance", "train_station_entrance", "tram_stop" },
 					shop = Set { "accessories", "alcohol", "antiques", "art", "bag", "bakery", "beauty", "bed", "beverages", "bicycle", "books", "boutique", "butcher", "camera", "car", "car_repair", "carpet", "charity", "chemist", "chocolate", "clothes", "coffee", "computer", "confectionery", "convenience", "copyshop", "cosmetics", "deli", "delicatessen", "department_store", "doityourself", "dry_cleaning", "electronics", "erotic", "fabric", "florist", "frozen_food", "furniture", "garden_centre", "general", "gift", "greengrocer", "hairdresser", "hardware", "hearing_aids", "hifi", "ice_cream", "interior_decoration", "jewelry", "kiosk", "lamps", "laundry", "mall", "massage", "mobile_phone", "motorcycle", "music", "musical_instrument", "newsagent", "optician", "outdoor", "perfume", "perfumery", "pet", "photo", "second_hand", "shoes", "sports", "stationery", "supermarket", "tailor", "tattoo", "ticket", "tobacco", "toys", "travel_agency", "video", "video_games", "watches", "weapons", "wholesale", "wine" },
 					sport = Set { "american_football", "archery", "athletics", "australian_football", "badminton", "baseball", "basketball", "beachvolleyball", "billiards", "bmx", "boules", "bowls", "boxing", "canadian_football", "canoe", "chess", "climbing", "climbing_adventure", "cricket", "cricket_nets", "croquet", "curling", "cycling", "disc_golf", "diving", "dog_racing", "equestrian", "fatsal", "field_hockey", "free_flying", "gaelic_games", "golf", "gymnastics", "handball", "hockey", "horse_racing", "horseshoes", "ice_hockey", "ice_stock", "judo", "karting", "korfball", "long_jump", "model_aerodrome", "motocross", "motor", "multi", "netball", "orienteering", "paddle_tennis", "paintball", "paragliding", "pelota", "racquet", "rc_car", "rowing", "rugby", "rugby_league", "rugby_union", "running", "sailing", "scuba_diving", "shooting", "shooting_range", "skateboard", "skating", "skiing", "soccer", "surfing", "swimming", "table_soccer", "table_tennis", "team_handball", "tennis", "toboggan", "volleyball", "water_ski", "yoga" },
@@ -654,6 +654,11 @@ function WritePOI(obj,class,subclass,rank)
 			isBike = "yes"
 		end
 		obj:Attribute("bike", isBike)
+	end
+
+	if class=="leisure" and subclass=="track" then
+		local sportType = obj:Find("sport")
+		obj:Attribute("sport", sportType)
 	end
 end
 

--- a/ansible/roles/tilemaker/templates/bicycle/process-openmaptiles.lua
+++ b/ansible/roles/tilemaker/templates/bicycle/process-openmaptiles.lua
@@ -570,12 +570,15 @@ function way_function(way)
 
 	-- Leisure tracks
 	if leisure=="track" then
-		way:Layer("poi", true)
-		way:Attribute("class", "leisure")
-		way:Attribute("subclass", "track")
+		way:Layer("landuse", true)
+		SetNameAttributes(way)
 		local sportType = way:Find("sport")
 		if sportType=="bmx" or sportType=="cycling" then
 			way:Attribute("sport", "bike")
+			way:Attribute("class", "leisure")
+			way:Attribute("subclass", "track")
+		elseif sportType=="athletics" then
+			way:Attribute("class", "pitch")
 		end
 	end
 
@@ -654,11 +657,6 @@ function WritePOI(obj,class,subclass,rank)
 			isBike = "yes"
 		end
 		obj:Attribute("bike", isBike)
-	end
-
-	if class=="leisure" and subclass=="track" then
-		local sportType = obj:Find("sport")
-		obj:Attribute("sport", sportType)
 	end
 end
 

--- a/ansible/roles/tilemaker/templates/bicycle/style.json
+++ b/ansible/roles/tilemaker/templates/bicycle/style.json
@@ -147,23 +147,6 @@
       }
     },
     {
-      "id": "landuse-track",
-      "type": "fill",
-      "metadata": {"mapbox:group": "1444849388993.3071"},
-      "source": "openmaptiles",
-      "source-layer": "poi",
-      "filter": [
-        "all",
-        ["==", "class", "leisure"],
-        ["==", "subclass", "track"]
-      ],
-      "layout": {"visibility": "visible"},
-      "paint": {
-        "fill-color": "#63b063",
-        "fill-opacity": {"base": 1, "stops": [[0, 0.9], [10, 0.3]]}
-      }
-    },
-    {
       "id": "landcover-wood",
       "type": "fill",
       "metadata": {"mapbox:group": "1444849388993.3071"},
@@ -2363,7 +2346,7 @@
       "id": "poi-pump-track",
       "type": "line",
       "source": "openmaptiles",
-      "source-layer": "poi",
+      "source-layer": "landuse",
       "minzoom": 15,
       "filter": [
         "all",
@@ -2440,14 +2423,11 @@
       "id": "poi-athletics",
       "type": "symbol",
       "source": "openmaptiles",
-      "source-layer": "poi",
+      "source-layer": "landuse",
       "minzoom": 15,
       "filter": [
         "all",
-        ["==", "$type", "Point"],
-        ["==", "class", "leisure"],
-        ["==", "subclass", "track"],
-        ["==", "sport", "athletics"],
+        ["==", "class", "pitch"],
         ["any", ["has", "name:latin"], ["has", "name:nonlatin"]]
       ],
       "layout": {

--- a/ansible/roles/tilemaker/templates/bicycle/style.json
+++ b/ansible/roles/tilemaker/templates/bicycle/style.json
@@ -2349,6 +2349,94 @@
       }
     },
     {
+      "id": "poi-sports-centre",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "poi",
+      "minzoom": 15,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["==", "class", "building"],
+        ["==", "subclass", "sports_centre"],
+        ["any", ["has", "name:latin"], ["has", "name:nonlatin"]]
+      ],
+      "layout": {
+        "text-anchor": "top",
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": ["Noto Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-padding": 2,
+        "text-size": 11
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "poi-pitch",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "poi",
+      "minzoom": 15,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["==", "class", "leisure"],
+        ["==", "subclass", "pitch"],
+        ["any", ["has", "name:latin"], ["has", "name:nonlatin"]]
+      ],
+      "layout": {
+        "text-anchor": "top",
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": ["Noto Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-padding": 2,
+        "text-size": 11
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "poi-athletics",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "poi",
+      "minzoom": 15,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["==", "class", "leisure"],
+        ["==", "subclass", "track"],
+        ["==", "sport", "athletics"],
+        ["any", ["has", "name:latin"], ["has", "name:nonlatin"]]
+      ],
+      "layout": {
+        "text-anchor": "top",
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": ["Noto Sans Regular"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-padding": 2,
+        "text-size": 11
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
+    },
+    {
       "id": "highway-name-path",
       "type": "symbol",
       "source": "openmaptiles",

--- a/ansible/roles/tilemaker/templates/bicycle/style.json
+++ b/ansible/roles/tilemaker/templates/bicycle/style.json
@@ -134,6 +134,36 @@
       "paint": {"fill-color": "hsla(30, 19%, 90%, 0.4)"}
     },
     {
+      "id": "landuse-sport",
+      "type": "fill",
+      "metadata": {"mapbox:group": "1444849388993.3071"},
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "filter": ["==", "class", "pitch"],
+      "layout": {"visibility": "visible"},
+      "paint": {
+        "fill-color": "#63b063",
+        "fill-opacity": {"base": 1, "stops": [[0, 0.9], [10, 0.3]]}
+      }
+    },
+    {
+      "id": "landuse-track",
+      "type": "fill",
+      "metadata": {"mapbox:group": "1444849388993.3071"},
+      "source": "openmaptiles",
+      "source-layer": "poi",
+      "filter": [
+        "all",
+        ["==", "class", "leisure"],
+        ["==", "subclass", "track"]
+      ],
+      "layout": {"visibility": "visible"},
+      "paint": {
+        "fill-color": "#63b063",
+        "fill-opacity": {"base": 1, "stops": [[0, 0.9], [10, 0.3]]}
+      }
+    },
+    {
       "id": "landcover-wood",
       "type": "fill",
       "metadata": {"mapbox:group": "1444849388993.3071"},


### PR DESCRIPTION
Based on [#17](https://github.com/buskerudbyen/cycling-norway/issues/17#issuecomment-1475870723)

Show name of the facilities on the map if:
* `building=sports_centre` (_poi-sports-centre_)
* `leisure=pitch` (_poi-pitch_)
* `leisure=track` and `sport=athletics` (_poi-athletics_)

[Sports centre example](https://overpass-turbo.eu/s/1sOm)
[Pitch example](https://overpass-turbo.eu/s/1sOn)
[Athletics track example](https://overpass-turbo.eu/s/1sOo)

![Képernyőkép_2023-03-23_18-37-01](https://user-images.githubusercontent.com/46535522/227292037-6b80b3e1-4c09-4139-bf99-300697e2029f.png)

**Question**: [Gamle gress](https://overpass-turbo.eu/s/1sOm) and [Marienlyst stadium](https://www.openstreetmap.org/relation/13850962) are so close to each other, only after zoom 17 they'll be both visible. Is this correct?
![Képernyőkép_2023-03-23_18-42-12](https://user-images.githubusercontent.com/46535522/227294658-425a32c2-0940-4905-a765-e5f0978337c5.png)
