### PR TITLE
Bicycle sports arenas with name

### DIFF
--- a/ansible/roles/tilemaker/templates/bicycle/style.json
+++ b/ansible/roles/tilemaker/templates/bicycle/style.json
@@ -2362,6 +2362,35 @@
       }
     },
     {
+      "id": "pump-track-name",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "minzoom": 17,
+      "filter": [
+        "all",
+        ["==", "class", "leisure"],
+        ["==", "subclass", "track"],
+        ["==", "sport", "bike"],
+        ["any", ["has", "name:latin"], ["has", "name:nonlatin"]]
+      ],
+      "layout": {
+        "symbol-placement": "point",
+        "symbol-spacing": 400,
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": ["Noto Sans Regular"],
+        "text-rotation-alignment": "map",
+        "text-size": {"base": 1, "stops": [[17, 10], [22, 21]]},
+        "text-offset": [0, 1.2]
+      },
+      "paint": {
+        "text-color": "#f0b811",
+        "text-halo-blur": 0.5,
+        "text-halo-width": 1,
+        "text-halo-color" :	"#fff"
+      }
+    },
+    {
       "id": "poi-bike-track",
       "type": "line",
       "source": "openmaptiles",


### PR DESCRIPTION
Based on [cycling-norway#32](https://github.com/buskerudbyen/cycling-norway/issues/32):
* added a rule that writes the name of the elements of the _poi-pump-track_ to the map, if it has any

Could not find any proper example on the development map, so I added a static string "Name of bike pump poi" for testing. It looks like this
* zoom 17:
![Képernyőkép_2023-05-10_01-07-21](https://github.com/buskerudbyen/proposal-visualizer/assets/46535522/4194fc3e-78ac-457e-9339-f2cf4fab8a84)
* zoom 21:
![Képernyőkép_2023-05-10_01-08-13](https://github.com/buskerudbyen/proposal-visualizer/assets/46535522/7fe1b4f7-dc83-4372-883f-e769cac8737f)
