### PR TITLE
"No bike" roads colored grey

### DIFF
--- a/ansible/roles/tilemaker/templates/bicycle/process-openmaptiles.lua
+++ b/ansible/roles/tilemaker/templates/bicycle/process-openmaptiles.lua
@@ -363,6 +363,10 @@ function way_function(way)
 			SetBrunnelAttributes(way)
 			if ramp then way:AttributeNumeric("ramp",1) end
 
+			-- No bike roads
+			if has_falsy_tag(way, "bicycle") or has_thruthy_tag(way, "motorroad") then
+				way:Attribute("no_bike", 1)
+			end
 
 			-- Service
 			if highway == "service" and service ~="" then way:Attribute("service", service) end
@@ -630,6 +634,10 @@ end
 
 function has_thruthy_tag(item, tag)
 	return item:Holds(tag) and item:Find(tag)~="no"
+end
+
+function has_falsy_tag(item, tag)
+	return item:Holds(tag) and item:Find(tag)=="no"
 end
 
 function has_value(arr, val)

--- a/ansible/roles/tilemaker/templates/bicycle/style.json
+++ b/ansible/roles/tilemaker/templates/bicycle/style.json
@@ -475,7 +475,7 @@
         "line-dasharray": [0.5, 0.25],
         "line-width": {
           "base": 1.2,
-          "stops": [[12, 1], [13, 3], [14, 4], [20, 15]]
+          "stops": [[12, 1], [20, 8]]
         }
       }
     },
@@ -579,7 +579,7 @@
         "line-dasharray": [0.5, 0.25],
         "line-width": {
           "base": 1.2,
-          "stops": [[5, 0.4], [6, 0.6], [7, 1.5], [20, 22]]
+          "stops": [[5, 0.4], [6, 0.6], [7, 1.5], [20, 12]]
         }
       }
     },
@@ -615,10 +615,10 @@
       ],
       "layout": {"line-join": "round", "visibility": "visible"},
       "paint": {
-        "line-color": "rgba(244, 209, 158, 1)",
+        "line-color": "#C0C0C0",
         "line-width": {
           "base": 1.2,
-          "stops": [[12.5, 0], [13, 1.5], [14, 2.5], [20, 11.5]]
+          "stops": [[12.5, 0], [13, 1.5], [14, 2], [20, 6]]
         }
       }
     },
@@ -724,8 +724,8 @@
       ],
       "layout": {"line-join": "round", "visibility": "visible"},
       "paint": {
-        "line-color": "#ffdaa6",
-        "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 18]]}
+        "line-color": "#C0C0C0",
+        "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.2], [20, 10]]}
       }
     },
     {
@@ -754,7 +754,6 @@
         "line-width": 1.1
       }
     },
-
     {
       "id": "aeroway-taxiway-casing",
       "type": "line",
@@ -910,11 +909,11 @@
       ],
       "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
-        "line-color": "#e9ac77",
+        "line-color": "#C0C0C0",
         "line-opacity": 1,
         "line-width": {
           "base": 1.2,
-          "stops": [[12, 1], [13, 3], [14, 4], [20, 15]]
+          "stops": [[12, 1], [13, 3], [14, 4], [20, 8]]
         }
       }
     },
@@ -1060,11 +1059,11 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "#e9ac77",
+        "line-color": "#C0C0C0",
         "line-opacity": {"stops": [[4, 0], [5, 1]]},
         "line-width": {
           "base": 1.2,
-          "stops": [[4, 0], [5, 0.4], [6, 0.6], [7, 1.5], [20, 22]]
+          "stops": [[5, 0], [6, 0.5], [7, 1.5], [20, 12]]
         }
       }
     },
@@ -1101,10 +1100,10 @@
       ],
       "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
-        "line-color": "#fc8",
+        "line-color": "#C0C0C0",
         "line-width": {
           "base": 1.2,
-          "stops": [[12.5, 0], [13, 1.5], [14, 2.5], [20, 11.5]]
+          "stops": [[12.5, 0], [13, 1.5], [14, 2.5], [20, 6]]
         }
       }
     },
@@ -1241,8 +1240,8 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "#fc8",
-        "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 18]]}
+        "line-color": "#C0C0C0",
+        "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 12]]}
       }
     },
     {
@@ -1369,11 +1368,11 @@
       ],
       "layout": {"line-join": "round"},
       "paint": {
-        "line-color": "#e9ac77",
+        "line-color": "#C0C0C0",
         "line-opacity": 1,
         "line-width": {
           "base": 1.2,
-          "stops": [[12, 1], [13, 3], [14, 4], [20, 19]]
+          "stops": [[12, 1], [13, 3], [14, 4], [20, 12]]
         }
       }
     },
@@ -1453,10 +1452,10 @@
       ],
       "layout": {"line-join": "round"},
       "paint": {
-        "line-color": "#e9ac77",
+        "line-color": "#C0C0C0",
         "line-width": {
           "base": 1.2,
-          "stops": [[5, 0.4], [6, 0.6], [7, 1.5], [20, 26]]
+          "stops": [[5, 0.4], [6, 0.6], [7, 1], [20, 12]]
         }
       }
     },
@@ -1531,10 +1530,10 @@
       ],
       "layout": {"line-join": "round"},
       "paint": {
-        "line-color": "#fc8",
+        "line-color": "#C0C0C0",
         "line-width": {
-          "base": 1.2,
-          "stops": [[12.5, 0], [13, 1.5], [14, 2.5], [20, 11.5]]
+          "base": 0.8,
+          "stops": [[12.5, 0], [13, 1], [20, 6]]
         }
       }
     },
@@ -1628,8 +1627,8 @@
       ],
       "layout": {"line-join": "round"},
       "paint": {
-        "line-color": "#fc8",
-        "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 18]]}
+        "line-color": "#C0C0C0",
+        "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 10]]}
       }
     },
     {

--- a/ansible/roles/tilemaker/templates/bicycle/style.json
+++ b/ansible/roles/tilemaker/templates/bicycle/style.json
@@ -615,7 +615,7 @@
       ],
       "layout": {"line-join": "round", "visibility": "visible"},
       "paint": {
-        "line-color": "#C0C0C0",
+        "line-color": "#ded7ce",
         "line-width": {
           "base": 1.2,
           "stops": [[12.5, 0], [13, 1.5], [14, 2], [20, 6]]
@@ -654,7 +654,7 @@
       ],
       "layout": {"line-join": "round"},
       "paint": {
-        "line-color": "#C0C0C0",
+        "line-color": "#ded7ce",
         "line-width": {"base": 1.2, "stops": [[15.5, 0], [16, 2], [20, 7.5]]}
       }
     },
@@ -712,7 +712,7 @@
       ],
       "layout": {"line-join": "round"},
       "paint": {
-        "line-color": "#C0C0C0",
+        "line-color": "#ded7ce",
         "line-opacity": 1,
         "line-width": {"base": 1.2, "stops": [[13.5, 0], [14, 2.5], [20, 11.5]]}
       }
@@ -751,7 +751,7 @@
       ],
       "layout": {"line-join": "round"},
       "paint": {
-        "line-color": "#C0C0C0",
+        "line-color": "#ded7ce",
         "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 10]]}
       }
     },
@@ -789,7 +789,7 @@
       ],
       "layout": {"line-join": "round"},
       "paint": {
-        "line-color": "#C0C0C0",
+        "line-color": "#ded7ce",
         "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 18]]}
       }
     },
@@ -807,7 +807,7 @@
       ],
       "layout": {"line-join": "round", "visibility": "visible"},
       "paint": {
-        "line-color": "#C0C0C0",
+        "line-color": "#ded7ce",
         "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.2], [20, 10]]}
       }
     },
@@ -992,7 +992,7 @@
       ],
       "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
-        "line-color": "#C0C0C0",
+        "line-color": "#ded7ce",
         "line-opacity": 1,
         "line-width": {
           "base": 1.2,
@@ -1142,7 +1142,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "#C0C0C0",
+        "line-color": "#ded7ce",
         "line-opacity": {"stops": [[4, 0], [5, 1]]},
         "line-width": {
           "base": 1.2,
@@ -1183,7 +1183,7 @@
       ],
       "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
-        "line-color": "#C0C0C0",
+        "line-color": "#ded7ce",
         "line-width": {
           "base": 1.2,
           "stops": [[12.5, 0], [13, 1.5], [14, 2.5], [20, 6]]
@@ -1254,7 +1254,7 @@
         "line-join": "round"
       },
       "paint": {
-        "line-color": "#C0C0C0",
+        "line-color": "#ded7ce",
         "line-opacity": 1,
         "line-width": {"base": 1.2, "stops": [[13.5, 0], [14, 2.5], [20, 11.5]]}
       }
@@ -1303,7 +1303,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "#C0C0C0",
+        "line-color": "#ded7ce",
         "line-width": {"base": 1.2, "stops": [[6.5, 0], [8, 0.5], [20, 13]]}
       }
     },
@@ -1351,7 +1351,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "#C0C0C0",
+        "line-color": "#ded7ce",
         "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 18]]}
       }
     },
@@ -1375,7 +1375,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "#C0C0C0",
+        "line-color": "#ded7ce",
         "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 12]]}
       }
     },
@@ -1503,7 +1503,7 @@
       ],
       "layout": {"line-join": "round"},
       "paint": {
-        "line-color": "#C0C0C0",
+        "line-color": "#ded7ce",
         "line-opacity": 1,
         "line-width": {
           "base": 1.2,
@@ -1587,7 +1587,7 @@
       ],
       "layout": {"line-join": "round"},
       "paint": {
-        "line-color": "#C0C0C0",
+        "line-color": "#ded7ce",
         "line-width": {
           "base": 1.2,
           "stops": [[5, 0.4], [6, 0.6], [7, 1], [20, 12]]
@@ -1665,7 +1665,7 @@
       ],
       "layout": {"line-join": "round"},
       "paint": {
-        "line-color": "#C0C0C0",
+        "line-color": "#ded7ce",
         "line-width": {
           "base": 0.8,
           "stops": [[12.5, 0], [13, 1], [20, 6]]
@@ -1728,7 +1728,7 @@
       ],
       "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
-        "line-color": "#C0C0C0",
+        "line-color": "#ded7ce",
         "line-opacity": 1,
         "line-width": {"base": 1.2, "stops": [[13.5, 0], [14, 2.5], [20, 11.5]]}
       }
@@ -1767,7 +1767,7 @@
       ],
       "layout": {"line-join": "round"},
       "paint": {
-        "line-color": "#C0C0C0",
+        "line-color": "#ded7ce",
         "line-width": {"base": 1.2, "stops": [[6.5, 0], [8, 0.5], [20, 13]]}
       }
     },
@@ -1785,7 +1785,7 @@
       ],
       "layout": {"line-join": "round"},
       "paint": {
-        "line-color": "#C0C0C0",
+        "line-color": "#ded7ce",
         "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 10]]}
       }
     },

--- a/ansible/roles/tilemaker/templates/bicycle/style.json
+++ b/ansible/roles/tilemaker/templates/bicycle/style.json
@@ -631,11 +631,30 @@
       "filter": [
         "all",
         ["==", "brunnel", "tunnel"],
-        ["in", "class", "service", "track"]
+        ["in", "class", "service", "track"],
+        ["!has", "no_bike"]
       ],
       "layout": {"line-join": "round"},
       "paint": {
         "line-color": "#fff",
+        "line-width": {"base": 1.2, "stops": [[15.5, 0], [16, 2], [20, 7.5]]}
+      }
+    },
+    {
+      "id": "tunnel-service-track-no_bike",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849354174.1904"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "tunnel"],
+        ["in", "class", "service", "track"],
+        ["has", "no_bike"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#C0C0C0",
         "line-width": {"base": 1.2, "stops": [[15.5, 0], [16, 2], [20, 7.5]]}
       }
     },
@@ -666,10 +685,34 @@
       "metadata": {"mapbox:group": "1444849354174.1904"},
       "source": "openmaptiles",
       "source-layer": "transportation",
-      "filter": ["all", ["==", "brunnel", "tunnel"], ["==", "class", "minor"]],
+      "filter": [
+        "all",
+        ["==", "brunnel", "tunnel"],
+        ["==", "class", "minor"],
+        ["!has", "no_bike"]
+      ],
       "layout": {"line-join": "round"},
       "paint": {
         "line-color": "#fff",
+        "line-opacity": 1,
+        "line-width": {"base": 1.2, "stops": [[13.5, 0], [14, 2.5], [20, 11.5]]}
+      }
+    },
+    {
+      "id": "tunnel-minor-no_bike",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849354174.1904"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "tunnel"],
+        ["==", "class", "minor"],
+        ["has", "no_bike"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#C0C0C0",
         "line-opacity": 1,
         "line-width": {"base": 1.2, "stops": [[13.5, 0], [14, 2.5], [20, 11.5]]}
       }
@@ -684,11 +727,31 @@
         "all",
         ["==", "brunnel", "tunnel"],
         ["in", "class", "secondary", "tertiary"],
-        ["!=", "ramp", 1]
+        ["!=", "ramp", 1],
+        ["!has", "no_bike"]
       ],
       "layout": {"line-join": "round"},
       "paint": {
         "line-color": "#fff4c6",
+        "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 10]]}
+      }
+    },
+    {
+      "id": "tunnel-secondary-tertiary-no_bike",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849354174.1904"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "tunnel"],
+        ["in", "class", "secondary", "tertiary"],
+        ["!=", "ramp", 1],
+        ["has", "no_bike"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#C0C0C0",
         "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 10]]}
       }
     },
@@ -702,11 +765,31 @@
         "all",
         ["==", "brunnel", "tunnel"],
         ["in", "class", "primary", "trunk"],
-        ["!=", "ramp", 1]
+        ["!=", "ramp", 1],
+        ["!has", "no_bike"]
       ],
       "layout": {"line-join": "round"},
       "paint": {
         "line-color": "#fff4c6",
+        "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 18]]}
+      }
+    },
+    {
+      "id": "tunnel-trunk-primary-no_bike",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849354174.1904"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "tunnel"],
+        ["in", "class", "primary", "trunk"],
+        ["!=", "ramp", 1],
+        ["has", "no_bike"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#C0C0C0",
         "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 18]]}
       }
     },
@@ -1143,7 +1226,8 @@
         "all",
         ["==", "$type", "LineString"],
         ["!=", "brunnel", "tunnel"],
-        ["in", "class", "minor", "service", "track"]
+        ["in", "class", "minor", "service", "track"],
+        ["!has", "no_bike"]
       ],
       "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
@@ -1153,16 +1237,41 @@
       }
     },
     {
-      "id": "highway-secondary-tertiary",
+      "id": "highway-minor-no_bike",
       "type": "line",
       "metadata": {"mapbox:group": "1444849345966.4436"},
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": [
         "all",
+        ["==", "$type", "LineString"],
+        ["!=", "brunnel", "tunnel"],
+        ["in", "class", "minor", "service", "track"],
+        ["has", "no_bike"]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#C0C0C0",
+        "line-opacity": 1,
+        "line-width": {"base": 1.2, "stops": [[13.5, 0], [14, 2.5], [20, 11.5]]}
+      }
+    },
+    {
+      "id": "highway-secondary-tertiary-primary",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
         ["!in", "brunnel", "bridge", "tunnel"],
-        ["in", "class", "secondary", "tertiary"],
-        ["!=", "ramp", 1]
+        ["in", "class", "primary", "secondary", "tertiary"],
+        ["!=", "ramp", 1],
+        ["!has", "no_bike"]
       ],
       "layout": {
         "line-cap": "round",
@@ -1175,7 +1284,7 @@
       }
     },
     {
-      "id": "highway-primary",
+      "id": "highway-secondary-tertiary-primary-no_bike",
       "type": "line",
       "metadata": {"mapbox:group": "1444849345966.4436"},
       "source": "openmaptiles",
@@ -1184,8 +1293,9 @@
         "all",
         ["==", "$type", "LineString"],
         ["!in", "brunnel", "bridge", "tunnel"],
-        ["in", "class", "primary"],
-        ["!=", "ramp", 1]
+        ["in", "class", "primary", "secondary", "tertiary"],
+        ["!=", "ramp", 1],
+        ["has", "no_bike"]
       ],
       "layout": {
         "line-cap": "round",
@@ -1193,7 +1303,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "#fea",
+        "line-color": "#C0C0C0",
         "line-width": {"base": 1.2, "stops": [[6.5, 0], [8, 0.5], [20, 13]]}
       }
     },
@@ -1208,7 +1318,8 @@
         ["==", "$type", "LineString"],
         ["!in", "brunnel", "bridge", "tunnel"],
         ["in", "class", "trunk"],
-        ["!=", "ramp", 1]
+        ["!=", "ramp", 1],
+        ["!has", "no_bike"]
       ],
       "layout": {
         "line-cap": "round",
@@ -1217,6 +1328,30 @@
       },
       "paint": {
         "line-color": "#fea",
+        "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 18]]}
+      }
+    },
+    {
+      "id": "highway-trunk-no_bike",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["in", "class", "trunk"],
+        ["!=", "ramp", 1],
+        ["has", "no_bike"]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#C0C0C0",
         "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 18]]}
       }
     },
@@ -1568,7 +1703,8 @@
         "all",
         ["==", "$type", "LineString"],
         ["==", "brunnel", "bridge"],
-        ["in", "class", "minor", "service", "track"]
+        ["in", "class", "minor", "service", "track"],
+        ["!has", "no_bike"]
       ],
       "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
@@ -1578,7 +1714,27 @@
       }
     },
     {
-      "id": "bridge-secondary-tertiary",
+      "id": "bridge-minor-no_bike",
+      "type": "line",
+      "metadata": {"mapbox:group": "1444849345966.4436"},
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["==", "brunnel", "bridge"],
+        ["in", "class", "minor", "service", "track"],
+        ["has", "no_bike"]
+      ],
+      "layout": {"line-cap": "round", "line-join": "round"},
+      "paint": {
+        "line-color": "#C0C0C0",
+        "line-opacity": 1,
+        "line-width": {"base": 1.2, "stops": [[13.5, 0], [14, 2.5], [20, 11.5]]}
+      }
+    },
+    {
+      "id": "bridge-secondary-tertiary-trunk-primary",
       "type": "line",
       "metadata": {"mapbox:group": "1444849334699.1902"},
       "source": "openmaptiles",
@@ -1586,8 +1742,9 @@
       "filter": [
         "all",
         ["==", "brunnel", "bridge"],
-        ["in", "class", "secondary", "tertiary"],
-        ["!=", "ramp", 1]
+        ["in", "class", "secondary", "tertiary", "primary", "trunk"],
+        ["!=", "ramp", 1],
+        ["!has", "no_bike"]
       ],
       "layout": {"line-join": "round"},
       "paint": {
@@ -1596,7 +1753,7 @@
       }
     },
     {
-      "id": "bridge-trunk-primary",
+      "id": "bridge-secondary-tertiary-trunk-primary-no_bike",
       "type": "line",
       "metadata": {"mapbox:group": "1444849334699.1902"},
       "source": "openmaptiles",
@@ -1604,12 +1761,13 @@
       "filter": [
         "all",
         ["==", "brunnel", "bridge"],
-        ["in", "class", "primary", "trunk"],
-        ["!=", "ramp", 1]
+        ["in", "class", "secondary", "tertiary", "primary", "trunk"],
+        ["!=", "ramp", 1],
+        ["has", "no_bike"]
       ],
       "layout": {"line-join": "round"},
       "paint": {
-        "line-color": "#fea",
+        "line-color": "#C0C0C0",
         "line-width": {"base": 1.2, "stops": [[6.5, 0], [8, 0.5], [20, 13]]}
       }
     },


### PR DESCRIPTION
Based on [cycling-norway#46](https://github.com/buskerudbyen/cycling-norway/issues/46):
* `highway = motorway` lines are narrower and grey
* `bicycle = no` OR `motorroad = yes` lines are grey

I kept the "casing" of the lines, that can indicate which group the line has (major or minor road, for example).

See Bergen for example:
![image](https://github.com/buskerudbyen/proposal-visualizer/assets/46535522/62625437-5b2c-4948-8345-9c370ecf8ecc)
