### PR TITLE
Closed roads at winter

### DIFF
--- a/ansible/roles/tilemaker/templates/bicycle/process-openmaptiles.lua
+++ b/ansible/roles/tilemaker/templates/bicycle/process-openmaptiles.lua
@@ -354,6 +354,13 @@ function way_function(way)
 			end
 		end
 
+		-- no snowplowing
+		local winter_months = Set { 'Nov', 'Dec', 'Jan', 'Feb' }
+		local current_month = os.date('%b')
+		if has_falsy_tag(way, "snowplowing") and winter_months[current_month] then
+			way:Attribute("snowplowing", "no")
+		end
+
 		-- Write to layer
 		if minzoom <= 14 then
 			way:Layer(layer, false)

--- a/ansible/roles/tilemaker/templates/bicycle/process-openmaptiles.lua
+++ b/ansible/roles/tilemaker/templates/bicycle/process-openmaptiles.lua
@@ -369,26 +369,6 @@ function way_function(way)
 			end
 		end
 
-		-- no snowplowing
-		local current_month = os.date('%b')
-		if has_falsy_tag(way, 'snowplowing') then
-			if way:Holds('motor_vehicle:conditional') then -- eg. 'no @ Nov-May'
-				local first, last = string.match(way:Find('motor_vehicle:conditional'), "(%u..)-(%u..)")
-				if monthMap[current_month] >= monthMap[first] or monthMap[current_month] <= monthMap[last] then
-					way:Attribute('snowplowing', 'no')
-				end
-			elseif way:Holds('opening_hours') then -- eg. 'Apr-Oct'
-				local last, first = string.match(way:Find('opening_hours'), "(%u..)-(%u..)")
-				if monthMap[current_month] > monthMap[last] or monthMap[current_month] < monthMap[first] then
-					way:Attribute('snowplowing', 'no')
-				end
-			else -- default closed Nov-Feb
-				if monthMap[current_month] >= monthMap['Nov'] or monthMap[current_month] <= monthMap['Feb'] then
-					way:Attribute('snowplowing', 'no')
-				end
-			end
-		end
-
 		-- Write to layer
 		if minzoom <= 14 then
 			way:Layer(layer, false)
@@ -437,6 +417,26 @@ function way_function(way)
 				end
 				if way:Holds("bicycle:conditional") then
 					way:Attribute("conditional_bike", way:Find("bicycle:conditional"))
+				end
+			end
+
+			-- no snowplowing
+			local current_month = os.date('%b')
+			if has_falsy_tag(way, 'snowplowing') then
+				if way:Holds('motor_vehicle:conditional') then -- eg. 'no @ Nov-May'
+					local first, last = string.match(way:Find('motor_vehicle:conditional'), "(%u..)-(%u..)")
+					if monthMap[current_month] >= monthMap[first] or monthMap[current_month] <= monthMap[last] then
+						way:Attribute('snowplowing', 'no')
+					end
+				elseif way:Holds('opening_hours') then -- eg. 'Apr-Oct'
+					local last, first = string.match(way:Find('opening_hours'), "(%u..)-(%u..)")
+					if monthMap[current_month] > monthMap[last] or monthMap[current_month] < monthMap[first] then
+						way:Attribute('snowplowing', 'no')
+					end
+				else -- default closed Nov-Feb
+					if monthMap[current_month] >= monthMap['Nov'] or monthMap[current_month] <= monthMap['Feb'] then
+						way:Attribute('snowplowing', 'no')
+					end
 				end
 			end
 

--- a/ansible/roles/tilemaker/templates/bicycle/style.json
+++ b/ansible/roles/tilemaker/templates/bicycle/style.json
@@ -2201,6 +2201,26 @@
       "paint": {"icon-opacity": 0.5}
     },
     {
+      "id": "no-snowplowing-winter_road",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 15,
+      "filter": [
+        "all",
+        ["==", "snowplowing", "no"]
+      ],
+      "layout": {
+        "icon-image": "information",
+        "icon-padding": 2,
+        "icon-rotation-alignment": "viewport",
+        "icon-size": {"stops": [[15, 1], [22, 1.5]]},
+        "symbol-placement": "line",
+        "symbol-spacing": 125
+      },
+      "paint": {"icon-opacity": 0.5}
+    },
+    {
       "id": "poi-level-3",
       "type": "symbol",
       "source": "openmaptiles",


### PR DESCRIPTION
Based on [cycling-norway#52](https://github.com/buskerudbyen/cycling-norway/issues/52):

There are some roads that won't be snowplowed at winter and thus got closed. I found 3 cases when we can display an icon and add the informational popup:
* When the way has `snowplowing = no`
  * and `motor_vehicle:conditional`, the icon will appear when the actual date is between the given two months (eg. 'no @ Nov-May' indicates that the road can be closed from November to May)
  * and `opening_hours`, the icon will appear when the actual date is not between or equal to the given two months (eg. 'Apr-Oct' indicates that the road is always open from April to October, thus can be closed from November to March)
  * and there are no additional tag indicating the time interval, the icon will appear from November to February.