### PR TITLE
Bugfix: pumptrack not visible on the map

### DIFF
--- a/ansible/roles/tilemaker/templates/bicycle/process-openmaptiles.lua
+++ b/ansible/roles/tilemaker/templates/bicycle/process-openmaptiles.lua
@@ -598,7 +598,7 @@ function way_function(way)
 		way:Layer("landuse", true)
 		SetNameAttributes(way)
 		local sportType = way:Find("sport")
-		if sportType=="bmx" or sportType=="cycling" then
+		if string.find(sportType, "bmx") or string.find(sportType, "cycling") then
 			way:Attribute("sport", "bike")
 			way:Attribute("class", "leisure")
 			way:Attribute("subclass", "track")


### PR DESCRIPTION
Based on [cycling-norway#64](https://github.com/buskerudbyen/cycling-norway/issues/64), I changed the condition: it will check if the `sport` tag contains any of `bmx` or `cycling`.