### PR TITLE
Change Bikely data URL

### DIFF
--- a/otp/router-config.json
+++ b/otp/router-config.json
@@ -14,7 +14,7 @@
       "type": "vehicle-parking",
       "feedId": "bikely",
       "sourceType": "bikely",
-      "url": "https://api.safebikely.com/api/v1/s/locations",
+      "url": "https://api.safebikely.com/api/services/app/Location/GetPins",
       "headers": {
         "X-Bikely-Token": "${BIKELY_TOKEN}",
         "Authorization": "${BIKELY_AUTHORIZATION}"


### PR DESCRIPTION
I changed the URL as they adviced but did not remove the credentials (but as far as we know it's not needed anymore for this endpoint).

Is this a sufficient change?

Closes [cycling-norway#100](https://github.com/buskerudbyen/cycling-norway/issues/100)